### PR TITLE
Update README.md with more hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Here's a summary of the data I have collected for different devices
 |---|---|---|---|
 | Apple M1 CPU | CPU | 0.8 | 46 |
 | Apple M1 GPU | GPU | 1.4 | 56 |
+| Apple M1 Pro CPU 10-core | CPU | 0.34 | 183 |
+| Apple M1 Pro GPU 16-core | GPU | 4.2 | 176 |
 | Apple M2 CPU | CPU | 1 | 60 |
 | Apple M2 GPU | GPU | 2 | 90 |
 | Apple M2 Ultra CPU | CPU | 4 | 311 |
@@ -71,6 +73,9 @@ Here's a summary of the data I have collected for different devices
 | Intel i5-12400 | CPU | 0.7 | 26 |
 | Intel i9-13900K (WSL2) | CPU | 1.2 | 49 |
 | Intel Xeon Silver 4116 | CPU | 0.5 | 20 |
+| Intel Xeon 8358 60-core	| CPU | 3.5 | 587 |
+| Intel Xeon 6330 56-core	| CPU | 6 |	651 |
+| Intel Xeon 6230 40-core	| CPU | 2 |	119 |
 | AMD Ryzen Threadripper 3960X 24-Cores | CPU | 1.4 | 44 |
 | AMD Ryzen Threadripper PRO 5975WX 32-Cores | CPU | 1.5 | 28 |
 | AMD Ryzen 5 4600HS | CPU | 0.4 | 22 |
@@ -79,6 +84,9 @@ Here's a summary of the data I have collected for different devices
 | AMD Epyc 7763 Engineering Sample | CPU | 3.2 | 115 |
 | AMD Epyc 7262 | CPU | 0.5 | 80 |
 | Nvidia T4 | GPU | 4 | 240 |
+| Nvidia A100 80GB | GPU | 18.9 | 1490 |
+| Nvidia A10 24GB | GPU | 17 | 485 |
+| Nvidia V100 32GB | GPU | 13 | 766 |
 | Nvidia GeForce GTX 1650 Ti Mobile | GPU | 3 | 172 |
 | Intel Arc 770 16GB | GPU | 15 | 452 |
 | Intel Arc 370m | GPU | 4 | 93 |

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Here's a summary of the data I have collected for different devices
 |---|---|---|---|
 | Apple M1 CPU | CPU | 0.8 | 46 |
 | Apple M1 GPU | GPU | 1.4 | 56 |
-| Apple M1 Pro CPU 10-core | CPU | 0.34 | 183 |
-| Apple M1 Pro GPU 16-core | GPU | 4.2 | 176 |
+| Apple M1 Pro CPU 10-core | CPU | 0.33 | 96 |
+| Apple M1 Pro GPU 16-core | GPU | 3.74 | 176 |
 | Apple M2 CPU | CPU | 1 | 60 |
 | Apple M2 GPU | GPU | 2 | 90 |
 | Apple M2 Ultra CPU | CPU | 4 | 311 |
@@ -73,9 +73,9 @@ Here's a summary of the data I have collected for different devices
 | Intel i5-12400 | CPU | 0.7 | 26 |
 | Intel i9-13900K (WSL2) | CPU | 1.2 | 49 |
 | Intel Xeon Silver 4116 | CPU | 0.5 | 20 |
-| Intel Xeon 8358 60-core	| CPU | 3.5 | 587 |
-| Intel Xeon 6330 56-core	| CPU | 6 |	651 |
-| Intel Xeon 6230 40-core	| CPU | 2 |	119 |
+| Intel Xeon 8358 60-core	| CPU | 3.5 | 96 |
+| Intel Xeon 6330 56-core	| CPU | 5.7 |	81 |
+| Intel Xeon 6230 40-core	| CPU | 1.9 |	17.5 |
 | AMD Ryzen Threadripper 3960X 24-Cores | CPU | 1.4 | 44 |
 | AMD Ryzen Threadripper PRO 5975WX 32-Cores | CPU | 1.5 | 28 |
 | AMD Ryzen 5 4600HS | CPU | 0.4 | 22 |
@@ -85,7 +85,7 @@ Here's a summary of the data I have collected for different devices
 | AMD Epyc 7262 | CPU | 0.5 | 80 |
 | Nvidia T4 | GPU | 4 | 240 |
 | Nvidia A100 80GB | GPU | 18.9 | 1490 |
-| Nvidia A10 24GB | GPU | 17 | 485 |
+| Nvidia A10 24GB | GPU | 14.48 | 469 |
 | Nvidia V100 32GB | GPU | 13 | 766 |
 | Nvidia GeForce GTX 1650 Ti Mobile | GPU | 3 | 172 |
 | Intel Arc 770 16GB | GPU | 15 | 452 |


### PR DESCRIPTION
I've pulled max values from TFLOPs & Bandwidth values, feel free to pick appropriate ones from the 
respective device logs

## M1 Pro CPU

size, elapsed_time, tflops
256, 0.0005593538284301758, 0.059987847216797244
304, 0.0005908966064453125, 0.09509096411641059
362, 0.001025557518005371, 0.09251149188055886
430, 0.001228189468383789, 0.1294702520200334
512, 0.001682615280151367, 0.15953465962572957
608, 0.0030365467071533205, 0.1480337591847565
724, 0.004410219192504883, 0.17210184230523587
861, 0.006131863594055176, 0.20818381596707666
1024, 0.009294986724853516, 0.23103676331865264
1217, 0.016164469718933105, 0.22301818053317105
1448, 0.025070834159851074, 0.2421959614620206
1722, 0.0366288423538208, 0.2788086502257347
2048, 0.07361485958099365, 0.23337501805730004
2435, 0.09577257633209228, 0.30149889306386146
2896, 0.14764692783355712, 0.32900405707567704
3444, 0.2531908988952637, 0.32267946882955006
4096, 0.41744539737701414, 0.32923815745864493
4870, 0.6827491044998169, 0.3383418659614836
5792, 1.140793538093567, 0.34065016429302947
6888, 1.9750975847244263, 0.33091835218622495
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 6.628036499023438e-05, 126.56248952817266 0.00593164, 9.150505065917969e-05, 129.64617706388745 0.008388608, 9.491443634033204e-05, 176.76147746210498 0.01186328, 0.00012929439544677733, 183.5080315586207 0.016777216, 0.00024094581604003907, 139.26131838049474 0.023726564, 0.00046222209930419923, 102.66304460871307 0.033554432, 0.0011895418167114258, 56.41572499361754 0.047453132, 0.0012070655822753907, 78.6256069211219 0.067108864, 0.0013490676879882812, 99.48924668127245 0.094906264, 0.002052450180053711, 92.48094294548615 0.134217728, 0.002723979949951172, 98.5453127159808 0.189812528, 0.004103612899780273, 92.50995775462323 0.268435456, 0.005647826194763184, 95.05797336642567 0.37962506, 0.007899641990661621, 96.1119656938289

## M1 Pro GPU

size, elapsed_time, tflops
256, 0.0022138118743896484, 0.015156857901148901
304, 0.0013698816299438476, 0.04101736001986042
362, 0.001481318473815918, 0.06404825004011266
430, 0.0016551733016967774, 0.09607090679688288
512, 0.0014131307601928712, 0.18995797385612256
608, 0.001836395263671875, 0.2447792329311508
724, 0.0022881031036376953, 0.33171881406624903
861, 0.002637624740600586, 0.4839789157078232
1024, 0.003349709510803223, 0.641095486362057
1217, 0.0051839351654052734, 0.6954119816269283
1448, 0.007088565826416015, 0.8565984901165876
1722, 0.010837626457214356, 0.9423131657395165
2048, 0.008125948905944824, 2.1141985241171604
2435, 0.012311911582946778, 2.3453162049990026
2896, 0.015201735496520995, 3.1954534587920564
3444, 0.020447921752929688, 3.99549185267664
4096, 0.03269836902618408, 4.203235744325417
4870, 0.06379284858703613, 3.6211363987740777
5792, 0.10152990818023681, 3.8275569548052117
6888, 0.17475757598876954, 3.7400154725538317
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 0.0002621650695800781, 31.997428236478722 0.00593164, 0.0002692461013793945, 44.061102237775614 0.008388608, 0.00028362274169921873, 59.153281924734365 0.01186328, 0.00039157867431640627, 60.59206375684364 0.016777216, 0.0004241943359375, 79.10155595510791 0.023726564, 0.0005208492279052734, 91.10722538813147 0.033554432, 0.0006862878799438477, 97.78529675548238 0.047453132, 0.0007982254028320312, 118.89657189971805 0.067108864, 0.0010725498199462891, 125.13892175817186 0.094906264, 0.0013504266738891602, 140.5574487456987 0.134217728, 0.0019067049026489258, 140.7850032939397 0.189812528, 0.0023155927658081053, 163.94292710079222 0.268435456, 0.00310976505279541, 172.6403451339192 0.37962506, 0.004302573204040527, 176.4641957252445

## XEON 8358

size, elapsed_time, tflops
256, 0.00029647350311279297, 0.11317851898297386
304, 9.427070617675781e-05, 0.5960380512547092
362, 0.0002655506134033203, 0.3572797471038104
430, 0.00020799636840820312, 0.764503732526364
512, 0.00030138492584228513, 0.8906731325390587
608, 0.0005938529968261719, 0.7569405667772988
724, 0.0006790399551391601, 1.117764635579436
861, 0.000674128532409668, 1.893637044907391
1024, 0.001002669334411621, 2.141766556828199
1217, 0.0015986204147338868, 2.255051038241682
1448, 0.0021265745162963867, 2.855321897948353
1722, 0.0034563302993774413, 2.954705485711096
2048, 0.0047583341598510746, 3.6104797617949753
2435, 0.012336397171020507, 2.340661163036415
2896, 0.013834071159362794, 3.511362469689469
3444, 0.034032034873962405, 2.400664699321507
4096, 0.041814112663269044, 3.2869035050152124
4870, 0.06926615238189697, 3.3349998239598135
5792, 0.11372687816619872, 3.417059471271946
6888, 0.18672747611999513, 3.5002670829438354
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 2.13623046875e-05, 392.6827242057143
0.00593164, 2.4962425231933594e-05, 475.2454895617956 0.008388608, 3.988742828369141e-05, 420.61413136679016 0.01186328, 4.0364265441894534e-05, 587.8110189854694 0.016777216, 5.896091461181641e-05, 569.0961922981319 0.023726564, 0.00013747215270996094, 345.1835667410891 0.033554432, 0.00029397010803222656, 228.28465264448988 0.047453132, 0.0006681442260742188, 142.0445770483357 0.067108864, 0.0011352777481079101, 118.22457387515216 0.094906264, 0.0017763376235961914, 106.85610971619516 0.134217728, 0.002633333206176758, 101.93751985899719 0.189812528, 0.0037518739700317383, 101.18278466501597 0.268435456, 0.0055429935455322266, 96.85577072928935 0.37962506, 0.007837438583374023, 96.8747776359789


## XEON 6330

size, elapsed_time, tflops
256, 0.0013569831848144532, 0.024727227555578046
304, 0.00020787715911865234, 0.2702987102490102
362, 0.0003171682357788086, 0.2991341669730317
430, 0.00029251575469970705, 0.5436083268856468
512, 0.0012938261032104492, 0.20747413839766785
608, 0.0015253305435180664, 0.29469771382354537
724, 0.0017906665802001954, 0.423868327243335
861, 0.0010010957717895507, 1.2751574804057368
1024, 0.002240705490112305, 0.9583962093529603
1217, 0.0023542404174804687, 1.5312669849828147
1448, 0.0025918245315551757, 2.342772325083511
1722, 0.0037412405014038085, 2.72969302352202
2048, 0.006177711486816406, 2.7809439176081363
2435, 0.01067197322845459, 2.7057157220943893
2896, 0.016159939765930175, 3.0059789192044626
3444, 0.02640402317047119, 3.0942066760253506
4096, 0.0407407283782959, 3.373502608883616
4870, 0.0643460988998413, 3.5900017242625677
5792, 0.06466176509857177, 6.009911817031167
6888, 0.1139094352722168, 5.737856891152687
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.6736984252929688e-05, 501.20188160729344 0.00593164, 2.613067626953125e-05, 453.99820033868616 0.008388608, 2.8443336486816406e-05, 589.8469755043085 0.01186328, 3.8909912109375e-05, 609.7818965333333 0.016777216, 5.14984130859375e-05, 651.5624460894815 0.023726564, 7.791519165039063e-05, 609.0356321386536 0.033554432, 0.00010750293731689453, 624.2514453551919 0.047453132, 0.00027811527252197266, 341.24794060887785 0.067108864, 0.0008167743682861329, 164.32656705625314 0.094906264, 0.0015955686569213868, 118.96230674663599 0.134217728, 0.0026828527450561525, 100.05597828455606 0.189812528, 0.004241847991943359, 89.49520509010006 0.268435456, 0.0063223600387573246, 84.91621937201845 0.37962506, 0.009334683418273926, 81.33646166442705

## Xeon 6230

size, elapsed_time, tflops
256, 0.0010660886764526367, 0.031474334866449294
304, 0.00024623870849609374, 0.2281888511484431
362, 0.0005856513977050781, 0.16200056274394398
430, 0.00030994415283203125, 0.5130408125046153
512, 0.0005215167999267578, 0.514720630356873
608, 0.0007848262786865235, 0.5727527686156194
724, 0.0017034292221069336, 0.44557580564527444
861, 0.002509737014770508, 0.5086408474223062
1024, 0.0020975828170776366, 1.023789683304083
1217, 0.0032780647277832033, 1.0997252724896214
1448, 0.004508113861083985, 1.3469169082920995
1722, 0.008554792404174805, 1.1937680791665093
2048, 0.012502551078796387, 1.3741090978733195
2435, 0.018181657791137694, 1.588156926156356
2896, 0.03142075538635254, 1.5459984228481962
3444, 0.051935124397277835, 1.5731069428666327
4096, 0.08043766021728516, 1.7086393748989965
4870, 0.1250579833984375, 1.8471640092261892
5792, 0.1885313034057617, 2.0612571979074517
6888, 0.33719596862792967, 1.9383269640011442
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 7.028579711914063e-05, 119.34997316428765 0.00593164, 0.00012004375457763672, 98.82463308266138 0.008388608, 0.0002074003219604492, 80.89291203318083 0.01186328, 0.00027370452880859375, 86.68676438522648 0.016777216, 0.00043044090270996096, 77.95363263283924 0.023726564, 0.0008523225784301758, 55.675080305158744 0.033554432, 0.0017113685607910156, 39.21356599479744 0.047453132, 0.0030213117599487303, 31.412271073148208 0.067108864, 0.005322694778442383, 25.21612333354141 0.094906264, 0.00805039405822754, 23.578041848275827 0.134217728, 0.013228082656860351, 20.29284688970279 0.189812528, 0.02080078125, 18.250519124131454
0.268435456, 0.025548791885375975, 21.01355376836048 0.37962506, 0.043202972412109374, 17.57402506377523


## A100

size, elapsed_time, tflops
256, 0.002331447601318359, 0.014392102134753549
304, 3.080368041992187e-05, 1.8240978751247061
362, 2.994537353515625e-05, 3.1682976299699366
430, 3.2901763916015625e-05, 4.832993161275362
512, 4.212856292724609e-05, 6.371816111163691
608, 5.0520896911621095e-05, 8.897534515001869
724, 7.560253143310547e-05, 10.039436955514953
861, 0.00011236667633056641, 11.360616898951088
1024, 0.0001495838165283203, 14.356390268952808
1217, 0.000510096549987793, 7.067231931065344
1448, 0.00038242340087890625, 15.877832711190983
1722, 0.0006107330322265625, 16.721607571754056
2048, 0.0009835720062255859, 17.466813893907972
2435, 0.0017895221710205079, 16.135774240524395
2896, 0.0027276754379272463, 17.808731052295986
3444, 0.004607152938842773, 17.733187036009557
4096, 0.007505059242248535, 18.312840583363993
4870, 0.012823867797851562, 18.013489349812296
5792, 0.02147409915924072, 18.096754759967332
6888, 0.03455429077148438, 18.91504712009237
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.559257507324219e-05, 537.9873408078287 0.00593164, 1.823902130126953e-05, 650.4340229688889 0.008388608, 1.7237663269042968e-05, 973.2883012125035 0.01186328, 2.257823944091797e-05, 1050.8596147227033 0.016777216, 2.8872489929199217e-05, 1162.1592762619982 0.023726564, 4.5919418334960936e-05, 1033.4000237949742 0.033554432, 5.440711975097656e-05, 1233.4573913700965 0.047453132, 7.600784301757813e-05, 1248.637775157641 0.067108864, 9.925365447998047e-05, 1352.269885710574 0.094906264, 0.00013952255249023439, 1360.4433449085986 0.134217728, 0.00018618106842041015, 1441.7978061757256 0.189812528, 0.0002614498138427734, 1451.9997181114572 0.268435456, 0.00036163330078125, 1484.5726619760337 0.37962506, 0.0005092620849609375, 1490.882872339176

## A10

size, elapsed_time, tflops
256, 0.002762103080749512, 0.012148146183919689
304, 2.9611587524414063e-05, 1.8975317670379388
362, 2.8324127197265624e-05, 3.349647999362155
430, 3.883838653564453e-05, 4.094248350251688
512, 5.6362152099609376e-05, 4.762689961263215
608, 6.475448608398438e-05, 6.9417804261005
724, 8.165836334228516e-05, 9.294906448449026
861, 0.00011780261993408204, 10.836386853826447
1024, 0.0001761913299560547, 12.188361643763184
1217, 0.0002950429916381836, 12.218458760819638
1448, 0.000606536865234375, 10.011023454697458
1722, 0.0006679296493530273, 15.289691221061997
2048, 0.0009727001190185547, 17.66204079560957
2435, 0.002006793022155762, 14.388791186338286
2896, 0.0033052921295166015, 14.696564287981499
3444, 0.005706667900085449, 14.316498909420798
4096, 0.01004166603088379, 13.6868676023777
4870, 0.017165017127990723, 13.457755636218252
5792, 0.026809144020080566, 14.49548355161666
6888, 0.04512190818786621, 14.485115199976391
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 2.727508544921875e-05, 307.55570007720274 0.00593164, 4.0030479431152345e-05, 296.35618080476473 0.008388608, 4.801750183105469e-05, 349.3979353409335 0.01186328, 6.451606750488282e-05, 367.76203072520326 0.016777216, 8.165836334228516e-05, 410.9123747600817 0.023726564, 0.0001129150390625, 420.25516170378376 0.033554432, 0.00014994144439697265, 447.5671437599873 0.047453132, 0.00020966529846191406, 452.6560413011781 0.067108864, 0.00028586387634277344, 469.51622470501417 0.094906264, 0.0004027605056762695, 471.2788998049559 0.134217728, 0.0005587100982666016, 480.4557083052932 0.189812528, 0.0007897615432739258, 480.6831368697431 0.268435456, 0.0011051177978515625, 485.8042400943321 0.37962506, 0.0016187191009521484, 469.04377637441894

## V100

size, elapsed_time, tflops
256, 0.030690264701843262, 0.0010933249460694523
304, 5.295276641845703e-05, 1.061114117362053
362, 5.4764747619628904e-05, 1.7324256957954898
430, 5.939006805419922e-05, 2.6774510487996785
512, 8.966922760009766e-05, 2.9936184707328475
608, 8.409023284912109e-05, 5.345584246466958
724, 0.00011615753173828125, 6.534288708115337
861, 0.00018210411071777343, 7.010027159564871
1024, 0.0002442836761474609, 8.790942079583244
1217, 0.0004059314727783203, 8.880736941450902
1448, 0.0006460428237915039, 9.398842554065151
1722, 0.0009737253189086914, 10.488007138856831
2048, 0.0014728546142578126, 11.664334699224284
2435, 0.0026775360107421874, 10.784290345359738
2896, 0.004237055778503418, 11.464668111864654
3444, 0.006832623481750488, 11.957267217521101
4096, 0.010555601119995118, 13.02047622959663
4870, 0.017989206314086913, 12.841178313637297
5792, 0.029790496826171874, 13.044814540809966
6888, 0.04945027828216553, 13.217236805312831
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 2.3126602172851562e-05, 362.7254854518763 0.00593164, 3.1065940856933596e-05, 381.87415776761316 0.008388608, 3.457069396972656e-05, 485.30168398388963 0.01186328, 4.5680999755859374e-05, 519.3966884876827 0.016777216, 5.745887756347656e-05, 583.9729807275021 0.023726564, 7.605552673339844e-05, 623.9274124856175 0.033554432, 9.97304916381836e-05, 672.9021676085488 0.047453132, 0.00013680458068847655, 693.7360103176298 0.067108864, 0.0001841306686401367, 728.9265226224421 0.094906264, 0.00025873184204101564, 733.6264701810836 0.134217728, 0.0003587007522583008, 748.3548732752569 0.189812528, 0.0005028009414672852, 755.020575124958 0.268435456, 0.0007034063339233399, 763.2443526709988 0.37962506, 0.0009901762008666993, 766.7828406049648