### PR TITLE
Added M3 Max 40 core GPU benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here's a summary of the data I have collected for different devices
 | Apple M2 GPU | GPU | 2 |  | NA | NA | 90 |
 | Apple M2 Ultra CPU | CPU | 4 |  |  |  | 311 |
 | Apple M2 Ultra GPU (76 Core) | GPU | 20 |  |  |  | 636 |
+| Apple M3 Max GPU (40 Core) | GPU | 11.4 |  |  |  | 318 |
 | SteamDeck CPU | CPU | 0.17 | 0.002 | 0.002 | 0.05 | 20 |
 | SteamDeck GPU | GPU | 1.22 | 2.2 | 0.5 | NA | 69 |
 | Samsung Exynos 2100 | CPU | 0.1 |  |  |  | 16 |


### PR DESCRIPTION
Ran the benchmark script on an Apple M3 Max and added the results to the table in the README.

Following  are the results from my local:

benchmarking mps using torch.float32
size, elapsed_time, tops
256, 0.0009494543075561524, 0.03534075492939457
304, 0.003894495964050293, 0.014427779234764765
362, 0.003753805160522461, 0.02527458190898619
430, 0.003812360763549805, 0.04171011346049455
512, 0.0005591392517089843, 0.48008694646197514
608, 0.0007103443145751953, 0.6328078014797932
724, 0.0038912296295166016, 0.19505578448586436
861, 0.00451350212097168, 0.28283021205829845
1024, 0.003986859321594238, 0.5386404371903645
1217, 0.004683756828308105, 0.7696750190385544
1448, 0.00521554946899414, 1.1642214919248084
1722, 0.00510857105255127, 1.9990791927812788
2048, 0.005438375473022461, 3.159007550917043
2435, 0.006398892402648926, 4.512550599857967
2896, 0.007756352424621582, 6.262794108968038
3444, 0.00794682502746582, 10.280773074231549
4096, 0.012038421630859376, 11.41669212845046
4870, 0.022327184677124023, 10.346248725065662
5792, 0.04279778003692627, 9.08017906164065
6888, 0.06317918300628662, 10.34511696802037
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 0.0001737356185913086, 48.28375475344037
0.00593164, 0.00017147064208984376, 69.18548770456063
0.008388608, 0.0001693248748779297, 99.08299658921993
0.01186328, 0.000176239013671875, 134.62717196190476
0.016777216, 0.00023963451385498047, 140.023369172548
0.023726564, 0.0003280162811279297, 144.66698981168196
0.033554432, 0.00039973258972167967, 167.88439503200286
0.047453132, 0.0004274129867553711, 222.04815235134487
0.067108864, 0.0005264759063720703, 254.93612599461645
0.094906264, 0.0007500648498535156, 253.06148933264845
0.134217728, 0.0009586572647094727, 280.0119144576149
0.189812528, 0.0013868570327758788, 273.7304906188905
0.268435456, 0.0017958402633666993, 298.9524864497229
0.37962506, 0.0023839712142944337, 318.4812448436839