### PR TITLE
Adding M4 Max Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Here's a summary of the data I have collected for different devices
 | Apple M2 Ultra CPU | CPU | 4 |  |  |  | 311 |
 | Apple M2 Ultra GPU (76 Core) | GPU | 20 |  |  |  | 636 |
 | Apple M3 Max GPU (40 Core) | GPU | 11.4 |  |  |  | 318 |
+| Apple M4 Max CPU (16C,40C,128G) | CPU | 2.85 |  |  |  | 336 |
+| Apple M4 Max GPU (16C,40C,128G) | GPU | 13.27 | 13.29 |  |  | 396 |
 | SteamDeck CPU | CPU | 0.17 | 0.002 | 0.002 | 0.05 | 20 |
 | SteamDeck GPU | GPU | 1.22 | 2.2 | 0.5 | NA | 69 |
 | Samsung Exynos 2100 | CPU | 0.1 |  |  |  | 16 |


### PR DESCRIPTION
```
❯ python benchmark.py --device mps --dtype float32
benchmarking mps using torch.float32
size, elapsed_time, tops
256, 0.00045917034149169924, 0.07307621805666338
304, 0.0004172325134277344, 0.13467054026634973
362, 0.0003969907760620117, 0.23898755769877128
430, 0.00038785934448242186, 0.40997851995082374
512, 0.00036101341247558595, 0.7435608947580399
608, 0.00046024322509765627, 0.9766823268384252
724, 0.00040690898895263673, 1.865298798027651
861, 0.00044083595275878906, 2.8957591911712535
1024, 0.0005026102066040039, 4.272662233642139
1217, 0.0006831884384155273, 5.276685645267599
1448, 0.000910639762878418, 6.667899900183358
1722, 0.0011583328247070312, 8.816497191627942
2048, 0.0015741586685180664, 10.91368330752411
2435, 0.002604818344116211, 11.085351043854503
2896, 0.004086995124816894, 11.885611993279861
3444, 0.006520748138427734, 12.529161230217237
4096, 0.010297775268554688, 13.346470464517122
4870, 0.018049192428588868, 12.798500925399042
5792, 0.029142546653747558, 13.334850615261068
6888, 0.049233317375183105, 13.275482396671816
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 0.00015282630920410156, 54.889816051219974
0.00593164, 0.00016062259674072267, 73.85810116835387
0.008388608, 0.00017309188842773438, 96.92664487281543
0.01186328, 0.00015730857849121093, 150.82813809372539
0.016777216, 0.00017957687377929689, 186.85274609045138
0.023726564, 0.000189971923828125, 249.79021659502007
0.033554432, 0.00026502609252929685, 253.216063971443
0.047453132, 0.00032765865325927733, 289.6498018775057
0.067108864, 0.0004100799560546875, 327.2964845472744
0.094906264, 0.0005669832229614258, 334.7762690553434
0.134217728, 0.0008083820343017578, 332.0650937422946
0.189812528, 0.001054835319519043, 359.8903534753574
0.268435456, 0.0014045953750610352, 382.22460470273927
0.37962506, 0.0019153833389282226, 396.3959091472771
```



```
❯ python benchmark.py --device mps --dtype float16
benchmarking mps using torch.float16
size, elapsed_time, tops
256, 0.0004209756851196289, 0.07970634216193465
304, 0.00041620731353759767, 0.135002260105466
362, 0.00035796165466308596, 0.26504474645279336
430, 0.0003414154052734375, 0.4657493409608939
512, 0.0003688335418701172, 0.7277956734600025
608, 0.00029354095458984376, 1.5313414260306173
724, 0.0004387378692626953, 1.7299779690217325
861, 0.0003534078598022461, 3.612128951275483
1024, 0.0004259347915649414, 5.04181318485362
1217, 0.0005287885665893555, 6.817414092842014
1448, 0.0007467508316040039, 8.13129966116993
1722, 0.002221512794494629, 4.597064721530547
2048, 0.0014549493789672852, 11.807881038578932
2435, 0.0029009103775024412, 9.9538841233904
2896, 0.003907108306884765, 12.432836373233586
3444, 0.0073182106018066405, 11.163863574496055
4096, 0.009383821487426757, 14.64637340513696
4870, 0.01972076892852783, 11.713671350098037
5792, 0.02624058723449707, 14.809558288585615
6888, 0.04922075271606445, 13.278871249985624
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 0.0001535177230834961, 54.64260302660662
0.00593164, 0.00015785694122314454, 75.15209599323364
0.008388608, 0.00015039443969726561, 111.55476248837033
0.01186328, 0.00015528202056884765, 152.7965691912176
0.016777216, 0.00016946792602539061, 197.9987174385594
0.023726564, 0.00021426677703857423, 221.467502595874
0.033554432, 0.0002744913101196289, 244.48447555863459
0.047453132, 0.00034079551696777346, 278.4844849029355
0.067108864, 0.00044112205505371095, 304.264378673285
0.094906264, 0.0005604267120361328, 338.69286371161064
0.134217728, 0.0008068084716796875, 332.7127384286714
0.189812528, 0.0010514974594116211, 361.03278481759156
0.268435456, 0.0013998985290527345, 383.5070191575121
0.37962506, 0.0019119501113891602, 397.1077045772673

```




```
✦ ❯ python benchmark.py --device cpu --dtype float32
benchmarking cpu using torch.float32
size, elapsed_time, tops
256, 7.491111755371093e-05, 0.44792326020155315
304, 3.9696693420410156e-05, 1.4154561289255976
362, 6.687641143798828e-05, 1.4186744467886772
430, 0.00010497570037841797, 1.5147696031251419
512, 0.00016472339630126953, 1.6296134127118598
608, 0.0002176046371459961, 2.065725390302285
724, 0.0004254817962646484, 1.7838761955585523
861, 0.0006045818328857422, 2.1114672862511425
1024, 0.0009474039077758789, 2.2667033884644012
1217, 0.0014473676681518554, 2.4907082735951875
1448, 0.0023389816284179687, 2.5960250008919448
1722, 0.0034947633743286134, 2.9222116069480477
2048, 0.005530691146850586, 3.1062788949592597
2435, 0.010434460639953614, 2.7673041038111927
2896, 0.016721701622009276, 2.9049937243266677
3444, 0.028553271293640138, 2.8613010372019083
4096, 0.047705435752868654, 2.8809914699025767
4870, 0.08201980590820312, 2.816424684771127
5792, 0.13027074337005615, 2.9831065373756496
6888, 0.22701699733734132, 2.879062122263794
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.2636184692382812e-05, 663.8560771477736
0.00593164, 1.7237663269042968e-05, 688.2185720210235
0.008388608, 2.9587745666503905e-05, 567.0325880553103
0.01186328, 4.3773651123046874e-05, 542.028352474074
0.016777216, 7.433891296386719e-05, 451.37103385288003
0.023726564, 0.00010764598846435547, 440.82579088131115
0.033554432, 0.00019016265869140626, 352.9024281728385
0.047453132, 0.00027120113372802734, 349.9478881057195
0.067108864, 0.00038743019104003906, 346.4307405669612
0.094906264, 0.0005646467208862305, 336.16156966622134
0.134217728, 0.000824880599975586, 325.4234079549754
0.189812528, 0.0012051582336425782, 315.0001762445644
0.268435456, 0.0016550302505493164, 324.38737105971853
0.37962506, 0.0022541284561157227, 336.82646520878734
```