### PR TITLE
Added 5060 TI Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Here's a summary of the data I have collected for different devices
 | Nvidia 4060ti | GPU | 12 | 42 | 46 | NA | 234 |
 | Nvidia 4070 Super | GPU | 23 |  |  |  | 411 |
 | Nvidia 4070 Ti Super | GPU | 31 | 91 | 89 | NA | 602 |
+| Nvidia 5060 Ti | GPU | 17.4 | 46 | 50 | NA | 384 |
 | Nvidia 5070 Ti | GPU | 32 | 98 | 98 | NA | 762 |
 | Nvidia 4090 | GPU | 58 | 150 | 168 | NA | 912 |
 | Nvidia 4090 (WSL2) | GPU | 53 |  |  |  | 885 |


### PR DESCRIPTION
```
❯ python benchmark.py --device cuda --dtype float32
benchmarking cuda using torch.float32
size, elapsed_time, tops
256, 0.008216571807861329, 0.004083750837289134
304, 4.746913909912109e-05, 1.183693849654003
362, 4.9114227294921875e-05, 1.9317387491467186
430, 5.4669380187988284e-05, 2.9086483046489313
512, 5.7220458984375e-05, 4.691249611844267
608, 7.407665252685547e-05, 6.068192995587049
724, 0.00010001659393310547, 7.588809198078169
861, 0.0001522064208984375, 8.386996780193684
1024, 0.00019252300262451172, 11.154426321660672
1217, 0.00036296844482421877, 9.931911926244288
1448, 0.0005369424819946289, 11.308575848652518
1722, 0.0008478164672851562, 12.045576478010457
2048, 0.0011645078659057618, 14.752900935226732
2435, 0.0026033401489257814, 11.091645385607736
2896, 0.003338170051574707, 14.551816570604352
3444, 0.005856060981750488, 13.951272881652688
4096, 0.007828164100646972, 17.556984205356798
4870, 0.016866683959960938, 13.695792637626145
5792, 0.02452263832092285, 15.847051246701891
6888, 0.03739986419677734, 17.475893353653376
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.537799835205078e-05, 545.4941409121241
0.00593164, 1.8715858459472656e-05, 633.8624555047134
0.008388608, 1.9431114196777344e-05, 863.4201739590675
0.01186328, 2.5200843811035157e-05, 941.4986330580889
0.016777216, 4.4226646423339844e-05, 758.6926595974555
0.023726564, 0.0001222372055053711, 388.2052751763448
0.033554432, 0.00017983913421630858, 373.160515326337
0.047453132, 0.00025408267974853517, 373.52512219222666
0.067108864, 0.0003504753112792969, 382.95915198728704
0.094906264, 0.0004993677139282227, 380.10572711411413
0.134217728, 0.0006991147994995118, 383.96477401446776
0.189812528, 0.0009910106658935548, 383.0685875188914
0.268435456, 0.0013947486877441406, 384.9230450744014
0.37962506, 0.0019731998443603517, 384.7811574534786
```



```
❯ python benchmark.py --device cuda --dtype float16
benchmarking cuda using torch.float16
size, elapsed_time, tops
256, 0.011140775680541993, 0.003011857788197347
304, 3.376007080078125e-05, 1.664360490579887
362, 8.840560913085938e-05, 1.073188193970399
430, 3.5429000854492186e-05, 4.488243985572006
512, 9.992122650146485e-05, 2.6864707870260656
608, 3.821849822998047e-05, 11.76161923723578
724, 5.412101745605469e-05, 14.024253121558555
861, 0.00013375282287597656, 9.544133234359442
1024, 8.089542388916016e-05, 26.54641690168285
1217, 0.00022304058074951172, 16.16284630306179
1448, 0.0001819133758544922, 33.37882525393229
1722, 0.00030291080474853516, 33.71434077591908
2048, 0.0004102468490600586, 41.87690709474513
2435, 0.0013869524002075196, 20.819262251306967
2896, 0.001136040687561035, 42.759417689773706
3444, 0.0019408226013183593, 42.09529748494442
4096, 0.0027982473373413088, 49.11608478562317
4870, 0.004929804801940918, 46.85836768000465
5792, 0.007674169540405273, 50.63890029141543
6888, 0.01402440071105957, 46.60420445834649
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.571178436279297e-05, 533.9054945194537
0.00593164, 1.8978118896484374e-05, 625.1030497125629
0.008388608, 1.9359588623046876e-05, 866.6101499712314
0.01186328, 2.5463104248046874e-05, 931.8015497588015
0.016777216, 4.5132637023925784e-05, 743.4626960133544
0.023726564, 0.00012085437774658203, 392.64715838017753
0.033554432, 0.00018019676208496093, 372.419921554189
0.047453132, 0.0002557277679443359, 371.12224754825286
0.067108864, 0.0003536224365234375, 379.55093946960085
0.094906264, 0.0004993438720703125, 380.1238757832849
0.134217728, 0.0007013082504272461, 382.763864301419
0.189812528, 0.0009911060333251953, 383.031727419058
0.268435456, 0.0013968229293823242, 384.35144548880265
0.37962506, 0.001975703239440918, 384.2936048507222
```



```
❯ python benchmark.py --device cuda --dtype bfloat16
benchmarking cuda using torch.bfloat16
size, elapsed_time, tops
256, 0.009450650215148926, 0.0035504892505929275
304, 3.981590270996094e-05, 1.411218236324024
362, 9.307861328125e-05, 1.0193088686583607
430, 3.8623809814453125e-05, 4.116994174419753
512, 0.00011718273162841797, 2.290742435081636
608, 4.932880401611328e-05, 9.112554682111629
724, 5.7244300842285155e-05, 13.25908146019905
861, 0.0001445293426513672, 8.8324954544303
1024, 9.546279907226562e-05, 22.495502634218262
1217, 0.0002413034439086914, 14.939573872655176
1448, 0.00018858909606933594, 32.197273917509904
1722, 0.0003032207489013672, 33.67987887702876
2048, 0.00046482086181640623, 36.96019390537953
2435, 0.0015883207321166991, 18.179782688801694
2896, 0.001219487190246582, 39.83349612895711
3444, 0.001978778839111328, 41.28784033525007
4096, 0.003093576431274414, 44.42720473383661
4870, 0.004932498931884766, 46.83277364881885
5792, 0.007899975776672364, 49.19148072877906
6888, 0.012856078147888184, 50.83945746326717
size (GB), elapsed_time, bandwidth (GB/s)
0.004194304, 1.6355514526367186e-05, 512.8917214115452
0.00593164, 1.862049102783203e-05, 637.1088701295776
0.008388608, 1.9764900207519533e-05, 848.8388923723039
0.01186328, 2.5773048400878905e-05, 920.5957956913968
0.016777216, 4.410743713378906e-05, 760.7431802990703
0.023726564, 0.00012145042419433593, 390.7201503394425
0.033554432, 0.00017964839935302734, 373.55670432734706
0.047453132, 0.00025451183319091797, 372.8952906044553
0.067108864, 0.00035295486450195315, 380.2688147941853
0.094906264, 0.0005002737045288086, 379.41735950079203
0.134217728, 0.0007009506225585938, 382.95915198728704
0.189812528, 0.000991082191467285, 383.0409417789757
0.268435456, 0.0013966321945190429, 384.4039354863088
0.37962506, 0.001975536346435547, 384.32606991509533
```